### PR TITLE
ci: restructure the build matrix around the supported compiler range

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-ubuntu-gcc:
-    name: Ubuntu GCC Build
+    name: Ubuntu GCC ${{ matrix.toolchain.gcc }} (${{ matrix.build_type }})
     runs-on: ${{ matrix.toolchain.os }}
     strategy:
       fail-fast: false
@@ -45,7 +45,7 @@ jobs:
       run: ./build/test/dross_test --gtest_color=yes
 
   build-ubuntu-clang:
-    name: Ubuntu Clang Build
+    name: Ubuntu Clang ${{ matrix.toolchain.clang }} (${{ matrix.build_type }})
     runs-on: ${{ matrix.toolchain.os }}
     strategy:
       fail-fast: false
@@ -103,6 +103,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+
+    - name: Report toolchain versions
+      run: |
+        cmake --version
+        pkg-config --version
 
     - name: Build and Install
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,8 +8,11 @@ on:
 
 # Compilers come from the runner images only. Pinning the OS pins the compiler
 # set, which keeps an upstream repository change from breaking a required gate.
-# ubuntu-24.04 covers the lower bound of the supported range, ubuntu-26.04 the
-# newest versions we verify.
+#
+# The lower bounds do not line up across compilers. GCC is verified from 13 on
+# ubuntu-24.04, but Clang starts at 20 on ubuntu-26.04: older Clang releases
+# cannot build this library's C++23 usage against the libstdc++ they are paired
+# with on ubuntu-24.04. Both are verified up to what ubuntu-26.04 provides.
 
 jobs:
   build-ubuntu-gcc:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,11 +52,20 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         toolchain:
-          - { os: ubuntu-24.04, clang: 18 }
-          - { os: ubuntu-26.04, clang: 22 }
+          - { os: ubuntu-24.04, clang: 18, stdlib_pkg: libstdc++-14-dev }
+          - { os: ubuntu-26.04, clang: 22, stdlib_pkg: '' }
 
     steps:
     - uses: actions/checkout@v7
+
+    # Clang picks the newest libstdc++ headers it can find. The 13 series that
+    # ubuntu-24.04 defaults to cannot be consumed by Clang for C++23, so pull in
+    # the 14 headers there.
+    - name: Install standard library headers
+      if: matrix.toolchain.stdlib_pkg != ''
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.toolchain.stdlib_pkg }}
 
     - name: Report toolchain versions
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         toolchain:
-          - { os: ubuntu-24.04, clang: 17 }
+          - { os: ubuntu-24.04, clang: 18 }
           - { os: ubuntu-26.04, clang: 22 }
 
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,20 +52,11 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         toolchain:
-          - { os: ubuntu-24.04, clang: 18, stdlib_pkg: libstdc++-14-dev }
-          - { os: ubuntu-26.04, clang: 22, stdlib_pkg: '' }
+          - { os: ubuntu-26.04, clang: 20 }
+          - { os: ubuntu-26.04, clang: 22 }
 
     steps:
     - uses: actions/checkout@v7
-
-    # Clang picks the newest libstdc++ headers it can find. The 13 series that
-    # ubuntu-24.04 defaults to cannot be consumed by Clang for C++23, so pull in
-    # the 14 headers there.
-    - name: Install standard library headers
-      if: matrix.toolchain.stdlib_pkg != ''
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.toolchain.stdlib_pkg }}
 
     - name: Report toolchain versions
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,85 +6,84 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+# Compilers come from the runner images only. Pinning the OS pins the compiler
+# set, which keeps an upstream repository change from breaking a required gate.
+# ubuntu-24.04 covers the lower bound of the supported range, ubuntu-26.04 the
+# newest versions we verify.
+
 jobs:
   build-ubuntu-gcc:
     name: Ubuntu GCC Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.toolchain.os }}
     strategy:
+      fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        gcc_version: [13, 14]
+        toolchain:
+          - { os: ubuntu-24.04, gcc: 13 }
+          - { os: ubuntu-26.04, gcc: 15 }
 
     steps:
     - uses: actions/checkout@v7
 
-    - name: Install dependencies and GCC ${{ matrix.gcc_version }}
+    - name: Report toolchain versions
       run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake build-essential software-properties-common
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo apt-get update
-        sudo apt-get install -y gcc-${{ matrix.gcc_version }} g++-${{ matrix.gcc_version }}
+        gcc-${{ matrix.toolchain.gcc }} --version
+        cmake --version
 
     - name: Configure CMake
       run: |
         cmake -S . -B build \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -DCMAKE_C_COMPILER=gcc-${{ matrix.gcc_version }} \
-          -DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc_version }}
+          -DCMAKE_C_COMPILER=gcc-${{ matrix.toolchain.gcc }} \
+          -DCMAKE_CXX_COMPILER=g++-${{ matrix.toolchain.gcc }}
 
     - name: Build
-      run: cmake --build build --config ${{ matrix.build_type }} -j$(nproc)
+      run: cmake --build build --config ${{ matrix.build_type }} -j"$(nproc)"
 
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
   build-ubuntu-clang:
     name: Ubuntu Clang Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.toolchain.os }}
     strategy:
+      fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        clang_version: [17, 18]
+        toolchain:
+          - { os: ubuntu-24.04, clang: 17 }
+          - { os: ubuntu-26.04, clang: 22 }
 
     steps:
     - uses: actions/checkout@v7
 
-    - name: Install dependencies and Clang ${{ matrix.clang_version }}
+    - name: Report toolchain versions
       run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake build-essential
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-        echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ matrix.clang_version }} main" | sudo tee /etc/apt/sources.list.d/llvm.list
-        sudo apt-get update
-        sudo apt-get install -y clang-${{ matrix.clang_version }} libc++-${{ matrix.clang_version }}-dev libc++abi-${{ matrix.clang_version }}-dev
+        clang-${{ matrix.toolchain.clang }} --version
+        cmake --version
 
+    # No -stdlib override: the default standard library is what most Clang
+    # users on Linux build against.
     - name: Configure CMake
       run: |
         cmake -S . -B build \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -DCMAKE_C_COMPILER=clang-${{ matrix.clang_version }} \
-          -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang_version }} \
-          -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
-          -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"
+          -DCMAKE_C_COMPILER=clang-${{ matrix.toolchain.clang }} \
+          -DCMAKE_CXX_COMPILER=clang++-${{ matrix.toolchain.clang }}
 
     - name: Build
-      run: cmake --build build --config ${{ matrix.build_type }} -j$(nproc)
+      run: cmake --build build --config ${{ matrix.build_type }} -j"$(nproc)"
 
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
   build-static-library:
     name: Static Library Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v7
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake build-essential
 
     - name: Configure CMake (Static)
       run: |
@@ -93,27 +92,22 @@ jobs:
           -DBUILD_SHARED_LIBS=OFF
 
     - name: Build
-      run: cmake --build build -j$(nproc)
+      run: cmake --build build -j"$(nproc)"
 
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
   install-test:
     name: Installation Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v7
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake build-essential pkg-config
-
     - name: Build and Install
       run: |
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-        cmake --build build -j$(nproc)
+        cmake --build build -j"$(nproc)"
         sudo cmake --install build
 
     - name: Test find_package

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,22 +6,28 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+# macOS users build with the Apple Clang that ships with the OS, so the OS
+# generation is the axis worth varying: pinning to the two current releases
+# covers two Apple Clang generations without a separate compiler axis.
+
 jobs:
   build-macos-clang:
     name: macOS Clang Build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-14, macos-15]
+        os: [macos-15, macos-26]
         build_type: [Debug, Release]
 
     steps:
     - uses: actions/checkout@v7
 
-    - name: Install dependencies
+    - name: Report toolchain versions
       run: |
-        brew update
-        brew install cmake
+        clang --version
+        xcrun --show-sdk-version
+        cmake --version
 
     - name: Configure CMake
       run: |
@@ -29,61 +35,17 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
     - name: Build
-      run: cmake --build build --config ${{ matrix.build_type }} -j$(sysctl -n hw.ncpu)
-
-    - name: Test
-      run: ./build/test/dross_test --gtest_color=yes
-
-  build-macos-gcc:
-    name: macOS GCC Build
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        build_type: [Debug, Release]
-        gcc_version: [13, 14]
-
-    steps:
-    - uses: actions/checkout@v7
-
-    - name: Install dependencies and GCC ${{ matrix.gcc_version }}
-      run: |
-        brew update
-        brew install cmake gcc@${{ matrix.gcc_version }}
-
-    - name: Configure CMake
-      run: |
-        # Find GCC path (different for Intel and Apple Silicon)
-        if [ -x "/usr/local/bin/gcc-${{ matrix.gcc_version }}" ]; then
-          GCC_PATH="/usr/local/bin"
-        elif [ -x "/opt/homebrew/bin/gcc-${{ matrix.gcc_version }}" ]; then
-          GCC_PATH="/opt/homebrew/bin"
-        else
-          echo "GCC ${{ matrix.gcc_version }} not found"
-          exit 1
-        fi
-
-        cmake -S . -B build \
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -DCMAKE_C_COMPILER=$GCC_PATH/gcc-${{ matrix.gcc_version }} \
-          -DCMAKE_CXX_COMPILER=$GCC_PATH/g++-${{ matrix.gcc_version }}
-
-    - name: Build
-      run: cmake --build build --config ${{ matrix.build_type }} -j$(sysctl -n hw.ncpu)
+      run: cmake --build build --config ${{ matrix.build_type }} -j"$(sysctl -n hw.ncpu)"
 
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
   build-static-library:
     name: macOS Static Library Build
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
     - uses: actions/checkout@v7
-
-    - name: Install dependencies
-      run: |
-        brew update
-        brew install cmake
 
     - name: Configure CMake (Static)
       run: |
@@ -92,27 +54,22 @@ jobs:
           -DBUILD_SHARED_LIBS=OFF
 
     - name: Build
-      run: cmake --build build -j$(sysctl -n hw.ncpu)
+      run: cmake --build build -j"$(sysctl -n hw.ncpu)"
 
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
   install-test:
     name: macOS Installation Test
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
     - uses: actions/checkout@v7
 
-    - name: Install dependencies
-      run: |
-        brew update
-        brew install cmake pkg-config
-
     - name: Build and Install
       run: |
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-        cmake --build build -j$(sysctl -n hw.ncpu)
+        cmake --build build -j"$(sysctl -n hw.ncpu)"
         sudo cmake --install build
 
     - name: Test find_package

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-macos-clang:
-    name: macOS Clang Build
+    name: macOS Clang (${{ matrix.os }}, ${{ matrix.build_type }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -65,6 +65,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+
+    - name: Report toolchain versions
+      run: |
+        cmake --version
+        pkg-config --version
 
     - name: Build and Install
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,8 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    # Resolve the newest g++ the toolchain PPA offers rather than pinning a
-    # major, so this keeps tracking upstream without edits.
+    # Resolve the newest versioned g++ available once the toolchain PPA is in
+    # place, rather than pinning a major, so this keeps tracking upstream
+    # without edits.
     - name: Install newest GCC
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
@@ -61,9 +62,10 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    # llvm.sh adds the apt.llvm.org repository and installs the current stable
-    # release. Query apt afterwards so the version comes from that repository
-    # rather than from whatever the runner image happens to ship.
+    # llvm.sh adds the apt.llvm.org repository for the current stable release,
+    # then we take the newest versioned clang package available. Tracking the
+    # stable release rather than trunk (llvm.sh all) is deliberate: this watches
+    # what users will actually reach for, not what is still in development.
     - name: Install newest Clang
       run: |
         wget https://apt.llvm.org/llvm.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,150 @@
+name: Nightly Toolchain Watch
+
+on:
+  schedule:
+    # 03:00 UTC daily
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+# Early warning for environments outside the verified range: the newest
+# compilers and the floating runner labels. These jobs deliberately use the
+# wiring the required gates avoid — floating OS labels and compilers from
+# external repositories — because breaking here is the signal we want, ahead
+# of users hitting it. They never gate a pull request and must not be added to
+# required status checks.
+
+jobs:
+  newest-gcc:
+    name: Newest GCC
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release]
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install newest GCC
+      run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+        sudo apt-get update
+        sudo apt-get install -y gcc-16 g++-16
+
+    - name: Report toolchain versions
+      run: |
+        gcc-16 --version
+        cmake --version
+
+    - name: Configure CMake
+      run: |
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_C_COMPILER=gcc-16 \
+          -DCMAKE_CXX_COMPILER=g++-16
+
+    - name: Build
+      run: cmake --build build -j"$(nproc)"
+
+    - name: Test
+      run: ./build/test/dross_test --gtest_color=yes
+
+  newest-clang:
+    name: Newest Clang
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release]
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install newest Clang
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh
+        version=$(find /usr/lib -maxdepth 1 -name 'llvm-[0-9]*' -printf '%f\n' \
+          | sed 's/llvm-//' | sort -n | tail -1)
+        echo "CLANG_VERSION=$version" >> "$GITHUB_ENV"
+
+    - name: Report toolchain versions
+      run: |
+        clang-"$CLANG_VERSION" --version
+        cmake --version
+
+    - name: Configure CMake
+      run: |
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_C_COMPILER=clang-"$CLANG_VERSION" \
+          -DCMAKE_CXX_COMPILER=clang++-"$CLANG_VERSION"
+
+    - name: Build
+      run: cmake --build build -j"$(nproc)"
+
+    - name: Test
+      run: ./build/test/dross_test --gtest_color=yes
+
+  libcxx:
+    name: Clang with libc++
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release]
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install libc++
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libc++-17-dev libc++abi-17-dev
+
+    - name: Report toolchain versions
+      run: |
+        clang-17 --version
+        cmake --version
+
+    - name: Configure CMake
+      run: |
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_C_COMPILER=clang-17 \
+          -DCMAKE_CXX_COMPILER=clang++-17 \
+          -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+          -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"
+
+    - name: Build
+      run: cmake --build build -j"$(nproc)"
+
+    - name: Test
+      run: ./build/test/dross_test --gtest_color=yes
+
+  floating-runners:
+    name: Floating Runner
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Report toolchain versions
+      run: |
+        cc --version
+        cmake --version
+
+    - name: Configure CMake
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      run: cmake --build build -j2
+
+    - name: Test
+      run: ./build/test/dross_test --gtest_color=yes

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,31 +17,36 @@ jobs:
   newest-gcc:
     name: Newest GCC
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [Release]
 
     steps:
     - uses: actions/checkout@v7
 
+    # Resolve the newest g++ the toolchain PPA offers rather than pinning a
+    # major, so this keeps tracking upstream without edits.
     - name: Install newest GCC
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
         sudo apt-get update
-        sudo apt-get install -y gcc-16 g++-16
+        version=$(apt-cache search --names-only '^g\+\+-[0-9]+$' \
+          | sed 's/^g++-//; s/ .*//' | sort -n | tail -1)
+        if [ -z "$version" ]; then
+          echo "No versioned g++ package found in the toolchain PPA" >&2
+          exit 1
+        fi
+        sudo apt-get install -y "gcc-$version" "g++-$version"
+        echo "GCC_VERSION=$version" >> "$GITHUB_ENV"
 
     - name: Report toolchain versions
       run: |
-        gcc-16 --version
+        gcc-"$GCC_VERSION" --version
         cmake --version
 
     - name: Configure CMake
       run: |
         cmake -S . -B build \
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -DCMAKE_C_COMPILER=gcc-16 \
-          -DCMAKE_CXX_COMPILER=g++-16
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_C_COMPILER=gcc-"$GCC_VERSION" \
+          -DCMAKE_CXX_COMPILER=g++-"$GCC_VERSION"
 
     - name: Build
       run: cmake --build build -j"$(nproc)"
@@ -52,21 +57,25 @@ jobs:
   newest-clang:
     name: Newest Clang
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [Release]
 
     steps:
     - uses: actions/checkout@v7
 
+    # llvm.sh adds the apt.llvm.org repository and installs the current stable
+    # release. Query apt afterwards so the version comes from that repository
+    # rather than from whatever the runner image happens to ship.
     - name: Install newest Clang
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh
-        version=$(find /usr/lib -maxdepth 1 -name 'llvm-[0-9]*' -printf '%f\n' \
-          | sed 's/llvm-//' | sort -n | tail -1)
+        version=$(apt-cache search --names-only '^clang-[0-9]+$' \
+          | sed 's/^clang-//; s/ .*//' | sort -n | tail -1)
+        if [ -z "$version" ]; then
+          echo "No versioned clang package found in the apt.llvm.org repository" >&2
+          exit 1
+        fi
+        sudo apt-get install -y "clang-$version"
         echo "CLANG_VERSION=$version" >> "$GITHUB_ENV"
 
     - name: Report toolchain versions
@@ -77,7 +86,7 @@ jobs:
     - name: Configure CMake
       run: |
         cmake -S . -B build \
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_COMPILER=clang-"$CLANG_VERSION" \
           -DCMAKE_CXX_COMPILER=clang++-"$CLANG_VERSION"
 
@@ -90,10 +99,6 @@ jobs:
   libcxx:
     name: Clang with libc++
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [Release]
 
     steps:
     - uses: actions/checkout@v7
@@ -111,7 +116,7 @@ jobs:
     - name: Configure CMake
       run: |
         cmake -S . -B build \
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_COMPILER=clang-17 \
           -DCMAKE_CXX_COMPILER=clang++-17 \
           -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
@@ -124,7 +129,7 @@ jobs:
       run: ./build/test/dross_test --gtest_color=yes
 
   floating-runners:
-    name: Floating Runner
+    name: Floating Runner (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -144,7 +149,7 @@ jobs:
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
     - name: Build
-      run: cmake --build build -j2
+      run: cmake --build build --parallel
 
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -98,9 +98,12 @@ jobs:
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
+  # The required gates build Clang against the default standard library.
+  # This covers the other choice, so neither ends up being the only one that
+  # works.
   libcxx:
     name: Clang with libc++
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
     - uses: actions/checkout@v7
@@ -108,19 +111,19 @@ jobs:
     - name: Install libc++
       run: |
         sudo apt-get update
-        sudo apt-get install -y libc++-17-dev libc++abi-17-dev
+        sudo apt-get install -y libc++-20-dev libc++abi-20-dev
 
     - name: Report toolchain versions
       run: |
-        clang-17 --version
+        clang-20 --version
         cmake --version
 
     - name: Configure CMake
       run: |
         cmake -S . -B build \
           -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_C_COMPILER=clang-17 \
-          -DCMAKE_CXX_COMPILER=clang++-17 \
+          -DCMAKE_C_COMPILER=clang-20 \
+          -DCMAKE_CXX_COMPILER=clang++-20 \
           -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
           -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 
 ### Requirements
 
-- **C++23** compatible compiler (GCC 13+, Clang 17+, MSVC 2022+)
+- **C++23** compatible compiler
+  - Verified in CI: GCC 13–15, Clang 17–22, Apple Clang (macOS 15 and 26)
+  - Newer versions are best effort, exercised by the nightly toolchain watch
 - **CMake 3.20+**
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@
 
 ### Requirements
 
-- **C++23** compatible compiler
-  - Verified in CI: GCC 13–15, Clang 17–22, Apple Clang (macOS 15 and 26)
+- **C++23** compatible compiler, verified in CI as:
+  - Linux: GCC 13–15 or Clang 17–22
+  - macOS: the Apple Clang shipped with macOS 15 or 26
   - Newer versions are best effort, exercised by the nightly toolchain watch
 - **CMake 3.20+**
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ### Requirements
 
 - **C++23** compatible compiler, verified in CI as:
-  - Linux: GCC 13–15 or Clang 17–22
+  - Linux: GCC 13–15 or Clang 20–22
   - macOS: the Apple Clang shipped with macOS 15 or 26
   - Newer versions are best effort, exercised by the nightly toolchain watch
 - **CMake 3.20+**

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -33,8 +33,8 @@ Development Setup
 Build Requirements
 ~~~~~~~~~~~~~~~~~~
 
-- C++23 compatible compiler (verified in CI: GCC 13-15, Clang 17-22,
-  Apple Clang on macOS 15 and 26; newer versions are best effort)
+- C++23 compatible compiler: on Linux, GCC 13-15 or Clang 17-22; on macOS,
+  the Apple Clang shipped with macOS 15 or 26. Newer versions are best effort.
 - CMake 3.20 or later
 - Git
 

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -33,7 +33,7 @@ Development Setup
 Build Requirements
 ~~~~~~~~~~~~~~~~~~
 
-- C++23 compatible compiler: on Linux, GCC 13-15 or Clang 17-22; on macOS,
+- C++23 compatible compiler: on Linux, GCC 13-15 or Clang 20-22; on macOS,
   the Apple Clang shipped with macOS 15 or 26. Newer versions are best effort.
 - CMake 3.20 or later
 - Git

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -33,7 +33,8 @@ Development Setup
 Build Requirements
 ~~~~~~~~~~~~~~~~~~
 
-- C++23 compatible compiler (GCC 13+, Clang 16+, MSVC 2022+)
+- C++23 compatible compiler (verified in CI: GCC 13-15, Clang 17-22,
+  Apple Clang on macOS 15 and 26; newer versions are best effort)
 - CMake 3.20 or later
 - Git
 

--- a/docs/sphinx/source/getting-started.rst
+++ b/docs/sphinx/source/getting-started.rst
@@ -10,11 +10,17 @@ To build and use dross, you need:
 
 - **C++ Compiler**: Supporting C++23 standard
 
-  - On Linux: GCC 13 through 15, or Clang 17 through 22
+  - On Linux: GCC 13 through 15, or Clang 20 through 22
   - On macOS: the Apple Clang shipped with macOS 15 or 26
 
   Newer versions are best effort: they are exercised by the nightly toolchain
   watch rather than by the required build matrix.
+
+  The Clang lower bound is higher than the GCC one because older Clang
+  releases cannot compile this library's C++23 ``std::expected`` usage against
+  the libstdc++ they are paired with on Ubuntu 24.04, whether or not newer
+  libstdc++ headers are installed alongside. Either standard library works
+  from Clang 20 onwards, so neither is imposed.
 
 - **Build System**: CMake 3.20 or later
 - **Operating System**: Linux or macOS

--- a/docs/sphinx/source/getting-started.rst
+++ b/docs/sphinx/source/getting-started.rst
@@ -9,13 +9,16 @@ System Requirements
 To build and use dross, you need:
 
 - **C++ Compiler**: Supporting C++23 standard
-  
-  - GCC 13 or later
-  - Clang 16 or later (with libc++ for full C++23 support)
-  - MSVC 2022 or later
+
+  - GCC 13 through 15
+  - Clang 17 through 22
+  - Apple Clang shipped with macOS 15 or 26
+
+  Newer versions are best effort: they are exercised by the nightly toolchain
+  watch rather than by the required build matrix.
 
 - **Build System**: CMake 3.20 or later
-- **Operating System**: Linux, macOS, Windows, or any POSIX-compliant system
+- **Operating System**: Linux or macOS
 
 Installation
 ------------

--- a/docs/sphinx/source/getting-started.rst
+++ b/docs/sphinx/source/getting-started.rst
@@ -10,9 +10,8 @@ To build and use dross, you need:
 
 - **C++ Compiler**: Supporting C++23 standard
 
-  - GCC 13 through 15
-  - Clang 17 through 22
-  - Apple Clang shipped with macOS 15 or 26
+  - On Linux: GCC 13 through 15, or Clang 17 through 22
+  - On macOS: the Apple Clang shipped with macOS 15 or 26
 
   Newer versions are best effort: they are exercised by the nightly toolchain
   watch rather than by the required build matrix.


### PR DESCRIPTION
## Why

The macOS GCC jobs have been failing since the `macos-latest` label moved to macOS 26. The SDK defines `xnu_static_assert_struct_size` only for Clang, so Homebrew GCC leaves the macro unexpanded and the build stops inside `mach/message.h`. Raising the GCC version does not help — the same failure is reported for 15, and the root cause sits in the SDK rather than in the compiler.

Looking into it surfaced a wider mismatch between what the documentation promises and what CI verifies:

- `MSVC 2022+` was declared without a single Windows job
- macOS was verified with 10 jobs without being declared in the requirements
- the three places stating the requirements disagreed: README said Clang 17+, `contributing.rst` said Clang 16+
- the macOS GCC jobs used a floating OS label with pinned compilers, so an OS change landed straight on a fixed configuration. The same shape existed on Linux, where a jammy-pinned `apt.llvm.org` list was being added to a noble runner
- `macos-14` is scheduled for removal in November, so the Clang matrix was already a generation stale

## What the verification found

Removing the `-stdlib=libc++` override exposed something the declared range had been hiding:

| Configuration | Result |
|---|---|
| ubuntu-24.04 / GCC 13 | pass |
| ubuntu-24.04 / Clang 17 + libstdc++ | **fail** |
| ubuntu-24.04 / Clang 18 + libstdc++ | **fail** |
| ubuntu-24.04 / Clang 18 + libstdc++ **14 headers** | **fail** |
| ubuntu-26.04 / GCC 15 | pass |
| ubuntu-26.04 / Clang 20, 22 | pass |

Clang on ubuntu-24.04 cannot compile the C++23 `std::expected` declarations in `platform/path.h` against the libstdc++ it is paired with, and installing newer libstdc++ headers alongside does not change that. GCC 13 builds fine on the same image, so libstdc++ 13 does provide `std::expected` — the failure is in how Clang consumes it.

The old configuration only ever worked because it forced libc++, which meant the declared Clang lower bound had never been verified against the standard library most Linux users get by default. So the lower bound moves to Clang 20, the oldest release that builds with either standard library without help.

## What changed

**Required gates** pin every runner image and take compilers from the image only:

| Compiler | Lower bound | Newest verified |
|---|---|---|
| GCC | `ubuntu-24.04` / 13 | `ubuntu-26.04` / 15 |
| Clang | `ubuntu-26.04` / 20 | `ubuntu-26.04` / 22 |
| Apple Clang | `macos-15` | `macos-26` |

The bounds deliberately do not line up across compilers — that asymmetry is what the table above measured, and `getting-started.rst` explains it so it does not read as arbitrary.

This removes the `ppa:ubuntu-toolchain-r/test` and `apt.llvm.org` dependencies from the required path, so an upstream repository change can no longer break a merge. All `apt-get install` / `brew install` steps are gone as well — `cmake` and `pkg-config` ship with the runner images, and the installation jobs now report their versions so a missing tool surfaces immediately.

Other changes to the required gates:

- **macOS Homebrew GCC jobs are dropped.** That combination was never declared as supported, and its breakage originates outside this project.
- **No standard library is imposed.** The required gates build against the default, and the nightly watch covers libc++ on the same Clang 20, so neither ends up being the only one that works.
- **Static library and installation jobs are pinned** to specific images instead of the floating labels.

**A nightly watch** (`nightly.yml`) covers what the required gates deliberately exclude: the newest GCC and Clang from external repositories, libc++, and the floating runner labels. Both version lookups resolve dynamically from apt, so they keep tracking upstream without edits. Breaking there is the signal we want ahead of users hitting it, so these jobs never gate a pull request and should not be added to required status checks.

**The requirements are restated** as a verified range plus best effort, with the README as the single source:

- Linux: GCC 13–15 or Clang 20–22
- macOS: the Apple Clang shipped with macOS 15 or 26
- Newer versions: best effort, exercised by the nightly watch

An open-ended `GCC 13+` cannot be verified by a finite matrix, so the old wording promised more than CI ever checked. MSVC and Windows are removed from the declared support for the same reason. The combinations are now stated per platform rather than as parallel lists, since listing compilers and operating systems on separate axes read as if macOS with GCC were supported.

## Effect on check count

Build checks go from 20 to 16: the four macOS GCC jobs are gone, and the rest is unchanged in count (contract verification 12, packaging 4).

## Notes

- `-Werror` is currently `PUBLIC` in `src/CMakeLists.txt`, so it propagates to consumers using `find_package` or `FetchContent`. Every time the newest verified compiler moves up, a newly added warning can break both this project and downstream builds. Worth addressing separately.
- The public headers and `docs/sphinx/source/api/platform.rst` still describe Windows behaviour. Those are descriptions of implementation branches rather than support declarations, so they are left as they are, but the asymmetry is worth knowing about.
- `main` has no branch protection configured today. If required status checks are added later, they will need to match the new job names.