### PR TITLE
ci: verify both standard libraries as required gates

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,6 +81,48 @@ jobs:
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
+  # The requirements say either standard library works with Clang, so both are
+  # verified here rather than leaving one to best effort. libc++ is not part of
+  # the runner image, but it comes from the distribution's own repository, so
+  # no external source enters a required gate. Verifying it at the lower bound
+  # is what matters: a newer libc++ paired with a newer Clang is the easier
+  # combination.
+  build-ubuntu-clang-libcxx:
+    name: Ubuntu Clang 20 libc++ (${{ matrix.build_type }})
+    runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install libc++
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libc++-20-dev libc++abi-20-dev
+
+    - name: Report toolchain versions
+      run: |
+        clang-20 --version
+        cmake --version
+
+    - name: Configure CMake
+      run: |
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_C_COMPILER=clang-20 \
+          -DCMAKE_CXX_COMPILER=clang++-20 \
+          -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+          -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"
+
+    - name: Build
+      run: cmake --build build --config ${{ matrix.build_type }} -j"$(nproc)"
+
+    - name: Test
+      run: ./build/test/dross_test --gtest_color=yes
+
   build-static-library:
     name: Static Library Build
     runs-on: ubuntu-24.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,19 +81,22 @@ jobs:
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
-  # The requirements say either standard library works with Clang, so both are
-  # verified here rather than leaving one to best effort. libc++ is not part of
-  # the runner image, but it comes from the distribution's own repository, so
-  # no external source enters a required gate. Verifying it at the lower bound
-  # is what matters: a newer libc++ paired with a newer Clang is the easier
-  # combination.
+  # The requirements say either standard library works across the whole Clang
+  # range, so libc++ is verified at both ends rather than left to best effort.
+  # Covering only the lower bound would leave the upper end of the declared
+  # range unverified against libc++ header changes and newly added warnings —
+  # and -Werror is public, so those reach consumers.
+  #
+  # libc++ is not part of the runner image, but it comes from the
+  # distribution's own repository, so no external source enters a required gate.
   build-ubuntu-clang-libcxx:
-    name: Ubuntu Clang 20 libc++ (${{ matrix.build_type }})
+    name: Ubuntu Clang ${{ matrix.clang }} libc++ (${{ matrix.build_type }})
     runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
+        clang: [20, 22]
 
     steps:
     - uses: actions/checkout@v7
@@ -101,19 +104,20 @@ jobs:
     - name: Install libc++
       run: |
         sudo apt-get update
-        sudo apt-get install -y libc++-20-dev libc++abi-20-dev
+        sudo apt-get install -y \
+          libc++-${{ matrix.clang }}-dev libc++abi-${{ matrix.clang }}-dev
 
     - name: Report toolchain versions
       run: |
-        clang-20 --version
+        clang-${{ matrix.clang }} --version
         cmake --version
 
     - name: Configure CMake
       run: |
         cmake -S . -B build \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -DCMAKE_C_COMPILER=clang-20 \
-          -DCMAKE_CXX_COMPILER=clang++-20 \
+          -DCMAKE_C_COMPILER=clang-${{ matrix.clang }} \
+          -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang }} \
           -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
           -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -98,41 +98,6 @@ jobs:
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
-  # The required gates build Clang against the default standard library.
-  # This covers the other choice, so neither ends up being the only one that
-  # works.
-  libcxx:
-    name: Clang with libc++
-    runs-on: ubuntu-26.04
-
-    steps:
-    - uses: actions/checkout@v7
-
-    - name: Install libc++
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libc++-20-dev libc++abi-20-dev
-
-    - name: Report toolchain versions
-      run: |
-        clang-20 --version
-        cmake --version
-
-    - name: Configure CMake
-      run: |
-        cmake -S . -B build \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_C_COMPILER=clang-20 \
-          -DCMAKE_CXX_COMPILER=clang++-20 \
-          -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
-          -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"
-
-    - name: Build
-      run: cmake --build build -j"$(nproc)"
-
-    - name: Test
-      run: ./build/test/dross_test --gtest_color=yes
-
   floating-runners:
     name: Floating Runner (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ### Requirements
 
 - **C++23** compatible compiler, verified in CI as:
-  - Linux: GCC 13–15 or Clang 20–22
+  - Linux: GCC 13–15, or Clang 20–22 with either libstdc++ or libc++
   - macOS: the Apple Clang shipped with macOS 15 or 26
   - Newer versions are best effort, exercised by the nightly toolchain watch
 - **CMake 3.20+**

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -33,8 +33,9 @@ Development Setup
 Build Requirements
 ~~~~~~~~~~~~~~~~~~
 
-- C++23 compatible compiler: on Linux, GCC 13-15 or Clang 20-22; on macOS,
-  the Apple Clang shipped with macOS 15 or 26. Newer versions are best effort.
+- C++23 compatible compiler: on Linux, GCC 13-15, or Clang 20-22 with either
+  libstdc++ or libc++; on macOS, the Apple Clang shipped with macOS 15 or 26.
+  Newer versions are best effort.
 - CMake 3.20 or later
 - Git
 

--- a/docs/sphinx/source/getting-started.rst
+++ b/docs/sphinx/source/getting-started.rst
@@ -10,7 +10,8 @@ To build and use dross, you need:
 
 - **C++ Compiler**: Supporting C++23 standard
 
-  - On Linux: GCC 13 through 15, or Clang 20 through 22
+  - On Linux: GCC 13 through 15, or Clang 20 through 22 with either libstdc++
+    or libc++
   - On macOS: the Apple Clang shipped with macOS 15 or 26
 
   Newer versions are best effort: they are exercised by the nightly toolchain
@@ -18,9 +19,10 @@ To build and use dross, you need:
 
   The Clang lower bound is higher than the GCC one because older Clang
   releases cannot compile this library's C++23 ``std::expected`` usage against
-  the libstdc++ they are paired with on Ubuntu 24.04, whether or not newer
-  libstdc++ headers are installed alongside. Either standard library works
-  from Clang 20 onwards, so neither is imposed.
+  the libstdc++ they are paired with on Ubuntu 24.04 — installing the
+  libstdc++ 14 headers alongside them does not change that either. From Clang
+  20 onwards both standard libraries work, and the build matrix verifies each
+  of them, so neither is imposed on you.
 
 - **Build System**: CMake 3.20 or later
 - **Operating System**: Linux or macOS


### PR DESCRIPTION
## Why

The requirements state that Clang works with either libstdc++ or libc++, but only libstdc++ was actually covered by a required gate. libc++ sat in the nightly watch, which makes it best effort — not something the project stands behind. A user picking libc++ had no guarantee it would keep building.

That gap was easy to miss because it reads fine either way: "the required gates build against the default standard library, the nightly watch covers the other one" sounds balanced, but only one of the two is a promise.

## What changed

- **`Ubuntu Clang 20 libc++` and `Ubuntu Clang 22 libc++` are now required gates** (Debug and Release each). Both ends of the declared Clang range are built against libc++ in addition to the default standard library.
- **The libc++ job is removed from `nightly.yml`**, since it is no longer best effort.
- **The requirements say so explicitly**: "Clang 20–22 with either libstdc++ or libc++".
- The getting started guide now names the libstdc++ headers that were actually tried (14) rather than implying every newer release was ruled out, and states that the matrix verifies each standard library.

Covering both ends rather than just the lower bound is deliberate. Stopping at the lower bound would have left the upper end of the declared range unverified against libc++ header changes and newly added warnings — and `-Werror` is `PUBLIC` here, so those reach consumers rather than staying in this project's CI.

libc++ is not part of the runner image, so this adds an `apt-get install`. It comes from the distribution's own repository, which is what the required gates already rely on for everything else — no external source enters the required path.

## Check count

Build checks go from 16 to 20 — the same total as before this series of changes, with the contents swapped: the four macOS Homebrew GCC jobs that were never part of the declared support are gone, and four libc++ jobs that the requirements do promise have taken their place.