### PR TITLE
Verify Clang against the older libstdc++ releases in the declared range

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -73,8 +73,8 @@ jobs:
     # that line — the captured output goes to the log rather than being
     # dropped, so the log never claims the driver said nothing when it said
     # something else. Reading the capture directly also leaves no pipeline
-    # whose exit status would turn on whether pipefail is set, which this
-    # workflow does not set. No branch fails the step.
+    # whose exit status would hinge on whether pipefail is set, which this
+    # step does not set. No branch fails the step.
     - name: Report toolchain versions
       run: |
         clang-${{ matrix.toolchain.clang }} --version
@@ -218,8 +218,8 @@ jobs:
     # on the test executable's — but that is CMake filling in language flags
     # for its own reasons, not a promise about linking. Naming the linker
     # variables states the requirement instead of resting on it. The libc++
-    # jobs below name CMAKE_EXE_LINKER_FLAGS for that same reason; they set no
-    # CMAKE_SHARED_LINKER_FLAGS, so the two are alike but not identical.
+    # jobs below set CMAKE_EXE_LINKER_FLAGS as well; they set no
+    # CMAKE_SHARED_LINKER_FLAGS.
     - name: Configure CMake
       run: |
         cmake -S . -B build \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,12 +67,25 @@ jobs:
     # that record cannot be derived from the image name either. Reported, not
     # asserted on: these two jobs exist to build against whatever the image
     # provides, so a change of release is news, not a failure.
+    #
+    # The driver's output is captured before it is filtered. Whenever the
+    # marker cannot be reported — the driver failed, or it stopped printing
+    # that line — the captured output goes to the log rather than being
+    # dropped, so the log never claims the driver said nothing when it said
+    # something else. Reading the capture directly also leaves no pipeline
+    # whose exit status would turn on whether pipefail is set, which this
+    # workflow does not set. No branch fails the step.
     - name: Report toolchain versions
       run: |
         clang-${{ matrix.toolchain.clang }} --version
-        clang++-${{ matrix.toolchain.clang }} -std=c++23 -E -x c++ -v /dev/null 2>&1 \
-          | grep -m1 'Selected GCC installation:' \
-          || echo "(the driver reported no GCC installation selection)"
+        if ! probe=$(clang++-${{ matrix.toolchain.clang }} -std=c++23 \
+          -E -x c++ -v /dev/null 2>&1); then
+          printf '%s\n' "$probe"
+          echo "(the driver exited non-zero; no GCC installation selection recorded)"
+        elif ! grep -m1 'Selected GCC installation:' <<< "$probe"; then
+          printf '%s\n' "$probe"
+          echo "(the driver reported no GCC installation selection)"
+        fi
         cmake --version
 
     # No -stdlib override: the default standard library is what most Clang
@@ -134,10 +147,10 @@ jobs:
     # This job's name claims a specific libstdc++, and a green build is not
     # evidence for that claim: were --gcc-install-dir to resolve to another
     # release than the one pinned, the build would still succeed, just not
-    # against what the name says. So the include search path is read back, and
-    # the first entry in it that canonicalises under /usr/include/c++ — the
-    # one the standard library headers are taken from — is compared against
-    # the pinned release. No other entry is examined.
+    # against what the name says. So the include search path is read back and
+    # its entries are canonicalised in order until one of them falls under
+    # /usr/include/c++. That one is where the standard library headers come
+    # from, and it is the only entry compared against the pinned release.
     #
     # The directory check and the search path check do not subsume each other:
     # the directory comes from libgcc-N-dev while the headers come from
@@ -204,8 +217,9 @@ jobs:
     # lines — the build file CMake writes puts it on the shared library's and
     # on the test executable's — but that is CMake filling in language flags
     # for its own reasons, not a promise about linking. Naming the linker
-    # variables states the requirement instead of resting on it, the same
-    # shape in which the libc++ jobs below pass -stdlib.
+    # variables states the requirement instead of resting on it. The libc++
+    # jobs below name CMAKE_EXE_LINKER_FLAGS for that same reason; they set no
+    # CMAKE_SHARED_LINKER_FLAGS, so the two are alike but not identical.
     - name: Configure CMake
       run: |
         cmake -S . -B build \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,6 +81,123 @@ jobs:
     - name: Test
       run: ./build/test/dross_test --gtest_color=yes
 
+  # The jobs above cover only the libstdc++ that comes with the runner image
+  # (15 on ubuntu-26.04), but the declared range promises the older releases a
+  # consumer may still be sitting on. Which libstdc++ Clang uses is an axis of
+  # its own — it does not follow from the Clang version the way it does for
+  # GCC — so the rest of the range is pinned here instead of being left to
+  # best effort. The pairing is what needs the evidence: these releases predate
+  # both Clang versions, and -Werror is public, so a diagnostic or a header
+  # difference on this axis reaches consumers.
+  #
+  # Like libc++ below, these headers come from the distribution's own
+  # repository (universe), so no external source enters a required gate.
+  build-ubuntu-clang-libstdcxx:
+    name: Ubuntu Clang ${{ matrix.clang }} libstdc++ ${{ matrix.libstdcxx }} (${{ matrix.build_type }})
+    runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+        clang: [20, 22]
+        # 15 is the runner default, already covered by the jobs above.
+        libstdcxx: [13, 14]
+
+    env:
+      # x86_64-linux-gnu is hardcoded: ubuntu-26.04 is an x86-64 runner today,
+      # so that is the only triple whose GCC installation this job has to name.
+      GCC_INSTALL_DIR: /usr/lib/gcc/x86_64-linux-gnu/${{ matrix.libstdcxx }}
+      LIBSTDCXX_HEADERS: /usr/include/c++/${{ matrix.libstdcxx }}
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install libstdc++ ${{ matrix.libstdcxx }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libstdc++-${{ matrix.libstdcxx }}-dev
+
+    - name: Report toolchain versions
+      run: |
+        clang-${{ matrix.clang }} --version
+        cmake --version
+
+    # This job's name claims a specific libstdc++, and a green build is not
+    # evidence for that claim: were --gcc-install-dir to resolve to another
+    # release than the one pinned, the build would still succeed, just not
+    # against what the name says. So the include search path is read back and
+    # its first standard library entry is compared against the pinned release.
+    #
+    # The directory check and the search path check do not subsume each other:
+    # the directory comes from libgcc-N-dev while the headers come from
+    # libstdc++-N-dev, so the directory can exist with no headers behind it —
+    # in which case Clang drops the standard library entries entirely and the
+    # comparison below reports that rather than a wrong version.
+    #
+    # What this does not cover is the flag going missing from the configure
+    # step below: this check would still pass, and the build would quietly fall
+    # back to the runner default.
+    - name: Verify the pinned libstdc++ is the one Clang selects
+      run: |
+        set -euo pipefail
+
+        if [ ! -d "$GCC_INSTALL_DIR" ]; then
+          echo "$GCC_INSTALL_DIR does not exist: installing libstdc++-${{ matrix.libstdcxx }}-dev did not bring in the GCC installation this job pins." >&2
+          exit 1
+        fi
+
+        search=$(clang++-${{ matrix.clang }} -std=c++23 \
+          "--gcc-install-dir=$GCC_INSTALL_DIR" -E -x c++ -v /dev/null 2>&1)
+        entries=$(printf '%s\n' "$search" | awk '
+          /search starts here:/ { inside = 1; next }
+          /End of search list/  { inside = 0 }
+          inside && NF          { print $1 }')
+        if [ -z "$entries" ]; then
+          echo "No include search path in the driver output below; the marker Clang prints may have changed." >&2
+          printf '%s\n' "$search" >&2
+          exit 1
+        fi
+        printf '%s\n' "$entries"
+
+        # Clang prints these relative to the GCC installation, as
+        # .../13/../../../../include/c++/13, so they are canonicalised before
+        # being compared.
+        selected=
+        while read -r entry; do
+          resolved=$(readlink -m "$entry")
+          case "$resolved" in
+            /usr/include/c++/*)
+              selected=$resolved
+              break
+              ;;
+          esac
+        done <<< "$entries"
+
+        if [ "$selected" != "$LIBSTDCXX_HEADERS" ]; then
+          echo "Expected $LIBSTDCXX_HEADERS to come first, found ${selected:-no standard library headers at all}." >&2
+          exit 1
+        fi
+        echo "$selected comes first in the include search path, as pinned."
+
+    # --gcc-install-dir has to reach the link as well as the compile: it
+    # selects the GCC installation the driver takes its startup files and its
+    # libstdc++ from. Setting both variables mirrors how the libc++ jobs below
+    # pass -stdlib.
+    - name: Configure CMake
+      run: |
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_C_COMPILER=clang-${{ matrix.clang }} \
+          -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang }} \
+          -DCMAKE_CXX_FLAGS="--gcc-install-dir=$GCC_INSTALL_DIR" \
+          -DCMAKE_EXE_LINKER_FLAGS="--gcc-install-dir=$GCC_INSTALL_DIR"
+
+    - name: Build
+      run: cmake --build build --config ${{ matrix.build_type }} -j"$(nproc)"
+
+    - name: Test
+      run: ./build/test/dross_test --gtest_color=yes
+
   # The requirements say either standard library works across the whole Clang
   # range, so libc++ is verified at both ends rather than left to best effort.
   # Covering only the lower bound would leave the upper end of the declared

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,9 +61,18 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
+    # The standard library is left to the image here, so the only record of
+    # which one a run used is this log. Clang selects the newest GCC
+    # installation it finds rather than the distribution's default alias, so
+    # that record cannot be derived from the image name either. Reported, not
+    # asserted on: these two jobs exist to build against whatever the image
+    # provides, so a change of release is news, not a failure.
     - name: Report toolchain versions
       run: |
         clang-${{ matrix.toolchain.clang }} --version
+        clang++-${{ matrix.toolchain.clang }} -std=c++23 -E -x c++ -v /dev/null 2>&1 \
+          | grep -m1 'Selected GCC installation:' \
+          || echo "(the driver reported no GCC installation selection)"
         cmake --version
 
     # No -stdlib override: the default standard library is what most Clang
@@ -125,8 +134,10 @@ jobs:
     # This job's name claims a specific libstdc++, and a green build is not
     # evidence for that claim: were --gcc-install-dir to resolve to another
     # release than the one pinned, the build would still succeed, just not
-    # against what the name says. So the include search path is read back and
-    # its first standard library entry is compared against the pinned release.
+    # against what the name says. So the include search path is read back, and
+    # the first entry in it that canonicalises under /usr/include/c++ — the
+    # one the standard library headers are taken from — is compared against
+    # the pinned release. No other entry is examined.
     #
     # The directory check and the search path check do not subsume each other:
     # the directory comes from libgcc-N-dev while the headers come from
@@ -146,12 +157,20 @@ jobs:
           exit 1
         fi
 
-        search=$(clang++-${{ matrix.clang }} -std=c++23 \
-          "--gcc-install-dir=$GCC_INSTALL_DIR" -E -x c++ -v /dev/null 2>&1)
+        # The driver's own output is the only diagnosis available when it
+        # refuses the pinned directory — a GCC installation it will not accept
+        # exists as far as the check above is concerned — so print it rather
+        # than letting the failed assignment end the step in silence.
+        if ! search=$(clang++-${{ matrix.clang }} -std=c++23 \
+          "--gcc-install-dir=$GCC_INSTALL_DIR" -E -x c++ -v /dev/null 2>&1); then
+          echo "The driver failed with --gcc-install-dir=$GCC_INSTALL_DIR; its output follows." >&2
+          printf '%s\n' "$search" >&2
+          exit 1
+        fi
         entries=$(printf '%s\n' "$search" | awk '
           /search starts here:/ { inside = 1; next }
           /End of search list/  { inside = 0 }
-          inside && NF          { print $1 }')
+          inside && NF          { sub(/^[ \t]+/, ""); print }')
         if [ -z "$entries" ]; then
           echo "No include search path in the driver output below; the marker Clang prints may have changed." >&2
           printf '%s\n' "$search" >&2
@@ -181,8 +200,12 @@ jobs:
 
     # --gcc-install-dir has to reach the link as well as the compile: it
     # selects the GCC installation the driver takes its startup files and its
-    # libstdc++ from. Setting both variables mirrors how the libc++ jobs below
-    # pass -stdlib.
+    # libstdc++ from. CMAKE_CXX_FLAGS alone already carries it to both link
+    # lines — the build file CMake writes puts it on the shared library's and
+    # on the test executable's — but that is CMake filling in language flags
+    # for its own reasons, not a promise about linking. Naming the linker
+    # variables states the requirement instead of resting on it, the same
+    # shape in which the libc++ jobs below pass -stdlib.
     - name: Configure CMake
       run: |
         cmake -S . -B build \
@@ -190,7 +213,8 @@ jobs:
           -DCMAKE_C_COMPILER=clang-${{ matrix.clang }} \
           -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang }} \
           -DCMAKE_CXX_FLAGS="--gcc-install-dir=$GCC_INSTALL_DIR" \
-          -DCMAKE_EXE_LINKER_FLAGS="--gcc-install-dir=$GCC_INSTALL_DIR"
+          -DCMAKE_EXE_LINKER_FLAGS="--gcc-install-dir=$GCC_INSTALL_DIR" \
+          -DCMAKE_SHARED_LINKER_FLAGS="--gcc-install-dir=$GCC_INSTALL_DIR"
 
     - name: Build
       run: cmake --build build --config ${{ matrix.build_type }} -j"$(nproc)"

--- a/README.md
+++ b/README.md
@@ -33,19 +33,25 @@
   - Clang 20–22 with libstdc++ 13, 14 or 15
   - Clang 20–22 with libc++ 20 or 22
 
+  The version in each pairing is the version of the standard library headers
+  the compiler builds against. The shared runtime a resulting binary loads
+  comes from the system's own runtime package, which is versioned and updated
+  separately.
+
   GCC with libc++ is not one of them, because upstream does not support that
   pairing: GCC has no `-stdlib` option to select libc++ with in the first
   place. It would be worth revisiting if GCC gained an equivalent option, or
   if libc++ started supporting GCC officially. On macOS the compiler is the
   Apple Clang shipped with macOS 15 or 26, and the standard library is not a
   separate axis there, because libc++ comes with the OS toolchain.
-- **What the required jobs build.** GCC 13 and 15, each against the libstdc++
-  paired with it, and Clang 20 and 22 against libstdc++ 13, 14 and 15 (15
-  being the release Ubuntu 26.04 provides) as well as against libc++ 20 and
-  22. Every libstdc++ release in the supported range is therefore covered in
-  the Clang pairings; among the GCC ones only 13 and 15 are, since the
+- **What the required Linux jobs build.** GCC 13 and 15, each against the
+  libstdc++ paired with it, and Clang 20 and 22 against libstdc++ 13, 14 and
+  15 (15 being the release Ubuntu 26.04 provides) as well as against libc++ 20
+  and 22. Every libstdc++ release in the supported range is therefore covered
+  in the Clang pairings; among the GCC ones only 13 and 15 are, since the
   libstdc++ version follows the compiler version there. GCC 14 and Clang 21
-  are inside the declared range but are not built by a required job. Newer
+  are inside the declared range but are not built by a required job. On macOS
+  the required jobs build with the Apple Clang of macOS 15 and 26. Newer
   versions are best effort: the nightly toolchain watch tracks the newest
   versioned GCC available once the toolchain PPA is in place, and the specific
   Clang release next in line to enter this range.

--- a/README.md
+++ b/README.md
@@ -23,19 +23,32 @@
 
 ### Requirements
 
-- **C++23** compatible compiler, verified in CI as:
-  - Linux: GCC 13–15, or Clang 20–22 with either libstdc++ or libc++
-  - macOS: the Apple Clang shipped with macOS 15 or 26
-  - Newer versions are best effort: the nightly toolchain watch tracks the
-    newest versioned GCC available once the toolchain PPA is in place, and
-    the specific Clang release next in line to enter this range
-  - Within the declared range, the required Linux jobs build GCC 13/15 and
-    Clang 20/22, with the Clang jobs pairing against the libstdc++ present
-    on Ubuntu 26.04 or against libc++. Clang against the older libstdc++
-    releases available on Ubuntu 24.04 (13 and 14) is not yet verified;
-    verification for that combination is to be added, and this sentence
-    will be removed once it is. GCC 14 and Clang 21 are inside the declared
-    range but are not built by a required job.
+- **A compiler configured for C++23 or later.** The public headers use C++23,
+  so C++17 and C++20 are outside the supported range. C++26 consumers are best
+  effort: no required job builds one, so neither compiling these headers as
+  C++26 nor the ABI and ODR compatibility of linking such a consumer against a
+  C++23 build of the library is verified.
+- **A supported compiler and standard library pairing.** On Linux those are:
+  - GCC 13–15 with the libstdc++ it is paired with (13, 14 or 15)
+  - Clang 20–22 with libstdc++ 13, 14 or 15
+  - Clang 20–22 with libc++ 20 or 22
+
+  GCC with libc++ is not one of them, because upstream does not support that
+  pairing: GCC has no `-stdlib` option to select libc++ with in the first
+  place. It would be worth revisiting if GCC gained an equivalent option, or
+  if libc++ started supporting GCC officially. On macOS the compiler is the
+  Apple Clang shipped with macOS 15 or 26, and the standard library is not a
+  separate axis there, because libc++ comes with the OS toolchain.
+- **What the required jobs build.** GCC 13 and 15, each against the libstdc++
+  paired with it, and Clang 20 and 22 against libstdc++ 13, 14 and 15 (15
+  being the release Ubuntu 26.04 provides) as well as against libc++ 20 and
+  22. Every libstdc++ release in the supported range is therefore covered in
+  the Clang pairings; among the GCC ones only 13 and 15 are, since the
+  libstdc++ version follows the compiler version there. GCC 14 and Clang 21
+  are inside the declared range but are not built by a required job. Newer
+  versions are best effort: the nightly toolchain watch tracks the newest
+  versioned GCC available once the toolchain PPA is in place, and the specific
+  Clang release next in line to enter this range.
 - **CMake 3.20+**
 
 ### Installation

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -33,16 +33,31 @@ Development Setup
 Build Requirements
 ~~~~~~~~~~~~~~~~~~
 
-- C++23 compatible compiler: on Linux, GCC 13-15, or Clang 20-22 with either
-  libstdc++ or libc++; on macOS, the Apple Clang shipped with macOS 15 or 26.
-  Newer versions are best effort.
-- Within that range, the required Linux jobs currently build GCC 13/15 and
-  Clang 20/22, with Clang built against the libstdc++ present on Ubuntu
-  26.04 or against libc++. Clang against the older libstdc++ releases
-  available on Ubuntu 24.04 (13 and 14) is not yet built by a required job;
-  verification for that combination is to be added, and this sentence will
-  be removed once it lands. GCC 14 and Clang 21 are inside the declared
-  range but are not built by a required job either.
+- A compiler configured for C++23 or later. The public headers use C++23, so
+  C++17 and C++20 are outside the supported range. C++26 consumers are best
+  effort: no required job builds one, so neither compiling these headers as
+  C++26 nor the ABI and ODR compatibility of linking such a consumer against a
+  C++23 build of the library is verified.
+- A supported compiler and standard library pairing. On Linux those are:
+
+  - GCC 13-15 with the libstdc++ it is paired with (13, 14 or 15)
+  - Clang 20-22 with libstdc++ 13, 14 or 15
+  - Clang 20-22 with libc++ 20 or 22
+
+  GCC with libc++ is not one of them, because upstream does not support that
+  pairing: GCC has no ``-stdlib`` option to select libc++ with in the first
+  place. It would be worth revisiting if GCC gained an equivalent option, or
+  if libc++ started supporting GCC officially. On macOS the compiler is the
+  Apple Clang shipped with macOS 15 or 26, and the standard library is not a
+  separate axis there, because libc++ comes with the OS toolchain.
+- The required Linux jobs build GCC 13/15, each against the libstdc++ paired
+  with it, and Clang 20/22 against libstdc++ 13, 14 and 15 (15 being the
+  release Ubuntu 26.04 provides) as well as against libc++ 20 and 22. Every
+  libstdc++ release in the supported range is therefore covered in the Clang
+  pairings; among the GCC ones only 13 and 15 are, since the libstdc++ version
+  follows the compiler version there. GCC 14 and Clang 21 are inside the
+  declared range but are not built by a required job either. Newer versions
+  are best effort.
 - CMake 3.20 or later
 - Git
 

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -44,6 +44,11 @@ Build Requirements
   - Clang 20-22 with libstdc++ 13, 14 or 15
   - Clang 20-22 with libc++ 20 or 22
 
+  The version in each pairing is the version of the standard library headers
+  the compiler builds against. The shared runtime a resulting binary loads
+  comes from the system's own runtime package, which is versioned and updated
+  separately.
+
   GCC with libc++ is not one of them, because upstream does not support that
   pairing: GCC has no ``-stdlib`` option to select libc++ with in the first
   place. It would be worth revisiting if GCC gained an equivalent option, or

--- a/docs/sphinx/source/getting-started.rst
+++ b/docs/sphinx/source/getting-started.rst
@@ -21,6 +21,11 @@ To build and use dross, you need:
   - Clang 20 through 22 with libstdc++ 13, 14 or 15
   - Clang 20 through 22 with libc++ 20 or 22
 
+  The version in each pairing is the version of the standard library headers
+  the compiler builds against. The shared runtime a resulting binary loads
+  comes from the system's own runtime package, which is versioned and updated
+  separately.
+
   GCC with libc++ is not one of them, because upstream does not support that
   pairing: GCC has no ``-stdlib`` option to select libc++ with in the first
   place. It would be worth revisiting if GCC gained an equivalent option, or
@@ -28,14 +33,14 @@ To build and use dross, you need:
   Apple Clang shipped with macOS 15 or 26, and the standard library is not a
   separate axis there, because libc++ comes with the OS toolchain.
 
-  The required build matrix builds GCC 13 and 15, each against the libstdc++
-  paired with it, and Clang 20 and 22 (not the intermediate 21) against
-  libstdc++ 13, 14 and 15 — 15 being the release Ubuntu 26.04 provides — as
-  well as against libc++ 20 and 22. Every libstdc++ release in the supported
-  range is therefore covered in the Clang pairings; among the GCC ones only 13
-  and 15 are, since the libstdc++ version follows the compiler version there.
-  GCC 14 and Clang 21 sit inside the declared range the same way, without a
-  required job of their own.
+  The required Linux build matrix builds GCC 13 and 15, each against the
+  libstdc++ paired with it, and Clang 20 and 22 (not the intermediate 21)
+  against libstdc++ 13, 14 and 15 — 15 being the release Ubuntu 26.04
+  provides — as well as against libc++ 20 and 22. Every libstdc++ release in
+  the supported range is therefore covered in the Clang pairings; among the
+  GCC ones only 13 and 15 are, since the libstdc++ version follows the
+  compiler version there. GCC 14 and Clang 21 sit inside the declared range
+  the same way, without a required job of their own.
 
   Newer versions are best effort: GCC is exercised by the nightly toolchain
   watch tracking the newest versioned GCC available once the toolchain PPA

--- a/docs/sphinx/source/getting-started.rst
+++ b/docs/sphinx/source/getting-started.rst
@@ -8,11 +8,34 @@ System Requirements
 
 To build and use dross, you need:
 
-- **C++ Compiler**: Supporting C++23 standard
+- **C++ Standard**: C++23 or later in your own project
 
-  - On Linux: GCC 13 through 15, or Clang 20 through 22 with either libstdc++
-    or libc++
-  - On macOS: the Apple Clang shipped with macOS 15 or 26
+  The public headers use C++23, so C++17 and C++20 are outside the supported
+  range. C++26 consumers are best effort: no required job builds one, so
+  neither compiling these headers as C++26 nor the ABI and ODR compatibility
+  of linking such a consumer against a C++23 build of the library is verified.
+
+- **C++ Compiler and Standard Library**: on Linux, one of these pairings
+
+  - GCC 13 through 15 with the libstdc++ it is paired with (13, 14 or 15)
+  - Clang 20 through 22 with libstdc++ 13, 14 or 15
+  - Clang 20 through 22 with libc++ 20 or 22
+
+  GCC with libc++ is not one of them, because upstream does not support that
+  pairing: GCC has no ``-stdlib`` option to select libc++ with in the first
+  place. It would be worth revisiting if GCC gained an equivalent option, or
+  if libc++ started supporting GCC officially. On macOS the compiler is the
+  Apple Clang shipped with macOS 15 or 26, and the standard library is not a
+  separate axis there, because libc++ comes with the OS toolchain.
+
+  The required build matrix builds GCC 13 and 15, each against the libstdc++
+  paired with it, and Clang 20 and 22 (not the intermediate 21) against
+  libstdc++ 13, 14 and 15 — 15 being the release Ubuntu 26.04 provides — as
+  well as against libc++ 20 and 22. Every libstdc++ release in the supported
+  range is therefore covered in the Clang pairings; among the GCC ones only 13
+  and 15 are, since the libstdc++ version follows the compiler version there.
+  GCC 14 and Clang 21 sit inside the declared range the same way, without a
+  required job of their own.
 
   Newer versions are best effort: GCC is exercised by the nightly toolchain
   watch tracking the newest versioned GCC available once the toolchain PPA
@@ -20,17 +43,12 @@ To build and use dross, you need:
   next in line to enter this range, rather than by the required build
   matrix.
 
-  The Clang lower bound is higher than the GCC one because older Clang
-  releases cannot compile this library's C++23 ``std::expected`` usage against
-  the libstdc++ they are paired with on Ubuntu 24.04 — installing the
-  libstdc++ 14 headers alongside them does not change that either. From Clang
-  20 onwards both standard libraries are supported, but the required build
-  matrix currently exercises only Clang 20 and 22 (not the intermediate 21),
-  and only against the libstdc++ present on Ubuntu 26.04 or against libc++
-  — not against the older libstdc++ releases available on Ubuntu 24.04
-  (13 and 14). Verification for that lower-bound combination is to be added;
-  this paragraph will be trimmed once it is. GCC 14 and Clang 21 sit inside
-  the declared range the same way, without a required job of their own.
+  The Clang lower bound is higher than the GCC one because Clang releases
+  older than 20 cannot compile this library's C++23 ``std::expected`` usage
+  against the libstdc++ they are paired with on Ubuntu 24.04 — and installing
+  the libstdc++ 14 headers alongside those older releases does not change that
+  either. From Clang 20 onwards both standard libraries work, which is why
+  every pairing listed above starts there.
 
 - **Build System**: CMake 3.20 or later
 - **Operating System**: Linux or macOS


### PR DESCRIPTION
## What

The required Linux jobs built Clang only against the libstdc++ that ships with
the runner image, so the two older releases the declared range promises — 13
and 14 — went unverified. This adds jobs that pin them, and settles the contract
documents around what the matrix actually covers.

## Why this axis needs jobs of its own

Which libstdc++ Clang uses does not follow from the Clang version the way it
does for GCC: the two come from different upstreams, and neither of them tests
the pairing. Both breakages this project has hit on that axis — `std::expected`
first, `std::views::split` later — happened there. `-Werror` is public, so a
header difference or a newly added diagnostic on this axis reaches consumers.

## The jobs

Six configurations, each in Debug and Release:

| Compiler | Standard library |
|---|---|
| Clang 20 / 22 | whatever the image provides (libstdc++ 15) — unchanged: no flag, no package step |
| Clang 20 / 22 | libstdc++ 13, pinned with `--gcc-install-dir` |
| Clang 20 / 22 | libstdc++ 14, pinned with `--gcc-install-dir` |

`libstdc++-13-dev` and `libstdc++-14-dev` come from the distribution's own
repository (universe), so no external source enters a required gate. Build-system
jobs go from 20 to 28.

A green build is not evidence for the release a job's name claims: were the pin
to resolve to another release, the build would still succeed, just not against
what the name says. Each pinned job therefore reads the include search path back
and compares its first standard library entry against the pin. The default jobs
report which installation the driver selected without asserting on it — they
exist to build against whatever the image provides, so a change of release there
is news rather than a failure.

## Measured

Ubuntu 26.04, along the path CI takes (configure, build, run the tests):

| | Release | Debug |
|---|---|---|
| Clang 20.1.8 × libstdc++ 13 | 405 passed | 405 passed |
| Clang 20.1.8 × libstdc++ 14 | 405 passed | 405 passed |
| Clang 22.1.2 × libstdc++ 13 | 405 passed | 405 passed |
| Clang 22.1.2 × libstdc++ 14 | 405 passed | 405 passed |

The lower bound holds against every declared release, so it stays at 20.

## Documents

The three files that publish the support range now state three axes — the C++
standard a consumer builds with, the compiler, and the standard library — and
list the pairings that hold instead of a product of two axes. GCC with libc++ is
noted as a pairing upstream does not support, along with what would make it
worth revisiting. Coverage is stated per quadrant: every libstdc++ release in
range is covered in the Clang pairings, while the GCC ones cover 13 and 15,
since the libstdc++ version follows the compiler version there. The provisional
notes that called this combination unverified are gone.

The version in each pairing is the version of the headers built against; the
runtime a binary loads comes from the system's runtime package, which is
versioned separately. The documents now say so, since the pin does not reach the
loader.
