### PR TITLE
Drop changelog entries for tooling this repository does not have

### DIFF
--- a/docs/sphinx/source/changelog.rst
+++ b/docs/sphinx/source/changelog.rst
@@ -85,9 +85,6 @@ Development Tools
 ^^^^^^^^^^^^^^^^^
 
 - Coding style guide (``CODINGSTYLE.md``)
-- Project documentation (``CLAUDE.md``)
-- Git hooks for code quality
-- VS Code configuration for development
 
 Known Issues
 ~~~~~~~~~~~~


### PR DESCRIPTION
## What

Three entries in the `v0.1.0` release notes name things this repository does not
contain:

- a project documentation file
- git hooks for code quality
- a VS Code configuration

None of the three appears anywhere in the history — neither added nor removed —
and nothing in the documentation explains how one would install the hooks.
`CODINGSTYLE.md`, the fourth entry in that list, does exist and stays.

## Why it matters

The changelog is rendered as part of the documentation site, so the list sends
readers looking for files that are not there.

## On editing release notes

Release notes record what a release contained, so rewriting them is normally off
limits. These three entries never described anything that existed, in that
release or in any other, so removing them corrects a record rather than revising
one.
